### PR TITLE
Implement name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ print `Hello, World!`.
 python hello.py
 ```
 
+You can optionally provide a name:
+
+```
+python hello.py --name Alice
+```
+
 ## Testing
 
 The project uses the built-in `unittest` module. To run the tests:

--- a/hello.py
+++ b/hello.py
@@ -5,9 +5,15 @@ def greet(name="World"):
     return f"Hello, {name}!"
 
 
-def main():
+import argparse
+
+
+def main(argv=None):
     """Print a greeting to stdout."""
-    print(greet())
+    parser = argparse.ArgumentParser(description="Print a greeting")
+    parser.add_argument("--name", default="World", help="Name to greet")
+    args = parser.parse_args(argv)
+    print(greet(args.name))
 
 
 if __name__ == "__main__":

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 import hello
 
 
@@ -8,6 +9,16 @@ class TestHello(unittest.TestCase):
 
     def test_greet_custom(self):
         self.assertEqual(hello.greet("Alice"), "Hello, Alice!")
+
+    def test_main_default(self):
+        with patch('sys.argv', ['hello.py']), patch('builtins.print') as mock_print:
+            hello.main()
+            mock_print.assert_called_once_with("Hello, World!")
+
+    def test_main_custom(self):
+        with patch('sys.argv', ['hello.py', '--name', 'Bob']), patch('builtins.print') as mock_print:
+            hello.main()
+            mock_print.assert_called_once_with("Hello, Bob!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--name` argparse option to `main()`
- update README usage example with `--name`
- test command-line interface via `unittest.mock.patch`

## Testing
- `python -m unittest discover -s tests`